### PR TITLE
Fix spacing for shortcut buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -1884,12 +1884,11 @@
             atalhosContainer.innerHTML = '';
             const snapshot = await db.collection('atalhos').get();
             if (!snapshot.empty) {
-                let html = '<div class="atalhos-bar"><h3>Atalhos Rápidos:</h3>';
+                let html = '<h3>Atalhos Rápidos:</h3>';
                 snapshot.forEach(doc => {
                     const atalho = doc.data();
                     html += `<a href="${atalho.link}" target="_blank" class="btn">${atalho.nome}</a>`;
                 });
-                html += '</div>';
                 atalhosContainer.innerHTML = html;
             }
         }


### PR DESCRIPTION
## Summary
- fix renderAtalhos to remove unnecessary wrapper div
- ensure "Atalhos Rápidos" header and buttons share flex container with a gap

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886c5a59a9c8332aad1d7dab255ab3a